### PR TITLE
HTTP content headers support

### DIFF
--- a/src/MockNet/Http/Contents/ByteArrayContent.cs
+++ b/src/MockNet/Http/Contents/ByteArrayContent.cs
@@ -1,20 +1,16 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using SystemHttpContent = System.Net.Http.HttpContent;
 using SystemByteArrayContent = System.Net.Http.ByteArrayContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class ByteArrayContent : IHttpContent
+    public class ByteArrayContent : HttpContent
     {
         private readonly byte[] content;
         private readonly int offset;
         private readonly int count;
 
-        public ByteArrayContent(byte[] content)
+        public ByteArrayContent(byte[] content) : this(content, 0, content.Length)
         {
-            this.content = content;
         }
 
         public ByteArrayContent(byte[] content, int offset, int count)
@@ -24,7 +20,7 @@ namespace Theorem.MockNet.Http
             this.count = count;
         }
 
-        public SystemHttpContent ToHttpContent() => new SystemByteArrayContent(content, offset, count);
+        protected override SystemHttpContent ToSystemHttpContent() => new SystemByteArrayContent(content, offset, count);
 
         #region Overrides
         public override string ToString()
@@ -71,7 +67,7 @@ namespace Theorem.MockNet.Http
 
         public static implicit operator byte[](ByteArrayContent content) => content.content;
         public static implicit operator ByteArrayContent(byte[] content) => new ByteArrayContent(content);
-        public static implicit operator SystemByteArrayContent(ByteArrayContent content) => content.ToHttpContent() as SystemByteArrayContent;
+        public static implicit operator SystemByteArrayContent(ByteArrayContent content) => content.ToSystemHttpContent() as SystemByteArrayContent;
 
         public static bool operator ==(ByteArrayContent content, byte[] bytes)
         {

--- a/src/MockNet/Http/Contents/FormUrlEncodedContent.cs
+++ b/src/MockNet/Http/Contents/FormUrlEncodedContent.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using SystemHttpContent = System.Net.Http.HttpContent;
 using SystemFormUrlEncodedContent = System.Net.Http.FormUrlEncodedContent;
-using System;
 
 namespace Theorem.MockNet.Http
 {
-    public class FormUrlEncodedContent : IHttpContent, IDictionary<string, string>
+    public class FormUrlEncodedContent : HttpContent, IDictionary<string, string>
     {
         private readonly IDictionary<string, string> content;
 
@@ -16,7 +15,7 @@ namespace Theorem.MockNet.Http
             this.content = nameValueCollection.ToDictionary(x => x.Key, x => x.Value);
         }
 
-        public SystemHttpContent ToHttpContent() => new SystemFormUrlEncodedContent(content);
+        protected override SystemHttpContent ToSystemHttpContent() => new SystemFormUrlEncodedContent(content);
 
         #region Overrides
         public override string ToString()

--- a/src/MockNet/Http/Contents/HttpContent.cs
+++ b/src/MockNet/Http/Contents/HttpContent.cs
@@ -1,0 +1,24 @@
+using SystemHttpContent = System.Net.Http.HttpContent;
+
+namespace Theorem.MockNet.Http
+{
+    public abstract class HttpContent
+    {
+        private HttpContentHeaders headers;
+
+        public HttpContentHeaders Headers => headers ??= new HttpContentHeaders();
+
+        protected abstract SystemHttpContent ToSystemHttpContent();
+
+        public SystemHttpContent ToHttpContent()
+        {
+            var content = ToSystemHttpContent();
+            foreach (var contentHeader in Headers)
+            {
+                content.Headers.Add(contentHeader.Key, contentHeader.Value);
+            }
+
+            return content;
+        }
+    }
+}

--- a/src/MockNet/Http/Contents/IHttpContent.cs
+++ b/src/MockNet/Http/Contents/IHttpContent.cs
@@ -1,9 +1,0 @@
-using SystemHttpContent = System.Net.Http.HttpContent;
-
-namespace Theorem.MockNet.Http
-{
-    public interface IHttpContent
-    {
-        SystemHttpContent ToHttpContent();
-    }
-}

--- a/src/MockNet/Http/Contents/MultipartContent.cs
+++ b/src/MockNet/Http/Contents/MultipartContent.cs
@@ -3,8 +3,8 @@ using SystemHttpContent = System.Net.Http.HttpContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class MultipartContent : IHttpContent
+    public class MultipartContent : HttpContent
     {
-        public SystemHttpContent ToHttpContent() => throw new NotImplementedException();
+        protected override SystemHttpContent ToSystemHttpContent() => throw new NotImplementedException();
     }
 }

--- a/src/MockNet/Http/Contents/MultipartFormDataContent.cs
+++ b/src/MockNet/Http/Contents/MultipartFormDataContent.cs
@@ -3,8 +3,8 @@ using SystemHttpContent = System.Net.Http.HttpContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class MultipartFormDataContent : IHttpContent
+    public class MultipartFormDataContent : HttpContent
     {
-        public SystemHttpContent ToHttpContent() => throw new NotImplementedException();
+        protected override SystemHttpContent ToSystemHttpContent() => throw new NotImplementedException();
     }
 }

--- a/src/MockNet/Http/Contents/ObjectContent.cs
+++ b/src/MockNet/Http/Contents/ObjectContent.cs
@@ -5,7 +5,7 @@ using SystemStringContent = System.Net.Http.StringContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class ObjectContent : IHttpContent
+    public class ObjectContent : HttpContent
     {
         internal readonly object value;
 
@@ -21,7 +21,7 @@ namespace Theorem.MockNet.Http
             this.mediaType = "application/json";
         }
 
-        public SystemHttpContent ToHttpContent() => new SystemStringContent(Utils.Json.ToString(value), encoding, mediaType);
+        protected override SystemHttpContent ToSystemHttpContent() => new SystemStringContent(Utils.Json.ToString(value), encoding, mediaType);
 
         #region Overrides
         public override string ToString()

--- a/src/MockNet/Http/Contents/ObjectContent{T}.cs
+++ b/src/MockNet/Http/Contents/ObjectContent{T}.cs
@@ -4,7 +4,7 @@ using SystemHttpContent = System.Net.Http.HttpContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class ObjectContent<T> : IHttpContent
+    public class ObjectContent<T> : HttpContent
     {
         private readonly ObjectContent content;
 
@@ -13,7 +13,7 @@ namespace Theorem.MockNet.Http
             this.content = new ObjectContent(typeof(T), content);
         }
 
-        public SystemHttpContent ToHttpContent() => content.ToHttpContent();
+        protected override SystemHttpContent ToSystemHttpContent() => content.ToHttpContent();
 
         #region Overrides
         public override string ToString()

--- a/src/MockNet/Http/Contents/StreamContent.cs
+++ b/src/MockNet/Http/Contents/StreamContent.cs
@@ -5,7 +5,7 @@ using SystemStreamContent = System.Net.Http.StreamContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class StreamContent : IHttpContent, IDisposable
+    public class StreamContent : HttpContent, IDisposable
     {
         private readonly Stream content;
         private readonly int bufferSize;
@@ -21,7 +21,7 @@ namespace Theorem.MockNet.Http
             this.bufferSize = bufferSize;
         }
 
-        public SystemHttpContent ToHttpContent() => new SystemStreamContent(content, bufferSize);
+        protected override SystemHttpContent ToSystemHttpContent() => new SystemStreamContent(content, bufferSize);
 
         #region Overrides
         public override string ToString()

--- a/src/MockNet/Http/Contents/StringContent.cs
+++ b/src/MockNet/Http/Contents/StringContent.cs
@@ -5,7 +5,7 @@ using SystemStringContent = System.Net.Http.StringContent;
 
 namespace Theorem.MockNet.Http
 {
-    public class StringContent : IHttpContent
+    public class StringContent : HttpContent
     {
         private readonly string value;
         private readonly Encoding encoding;
@@ -30,7 +30,7 @@ namespace Theorem.MockNet.Http
             this.mediaType = mediaType;
         }
 
-        public SystemHttpContent ToHttpContent() => new SystemStringContent(value, encoding, mediaType);
+        protected override SystemHttpContent ToSystemHttpContent() => new SystemStringContent(value, encoding, mediaType);
 
         #region Overrides
         public override string ToString()

--- a/src/MockNet/Http/Headers/HttpContentHeaders.cs
+++ b/src/MockNet/Http/Headers/HttpContentHeaders.cs
@@ -10,11 +10,11 @@ namespace Theorem.MockNet.Http
         internal HttpContentHeaders(SystemHttpContentHeaders contentHeadersStore)
         {
             this.contentHeadersStore = contentHeadersStore;
+            store = contentHeadersStore;
         }
-        
-        internal HttpContentHeaders()
+
+        internal HttpContentHeaders() : this(new System.Net.Http.ByteArrayContent(new byte[] { }).Headers)
         {
-            contentHeadersStore = new System.Net.Http.ByteArrayContent(new byte[]{}).Headers;
         }
 
         public HttpHeaderValueCollection<string> Allow =>

--- a/src/MockNet/Http/Headers/HttpContentHeaders.cs
+++ b/src/MockNet/Http/Headers/HttpContentHeaders.cs
@@ -1,0 +1,78 @@
+using System;
+using SystemHttpContentHeaders = System.Net.Http.Headers.HttpContentHeaders;
+
+namespace Theorem.MockNet.Http
+{
+    public class HttpContentHeaders : HttpHeaders
+    {
+        private readonly SystemHttpContentHeaders contentHeadersStore;
+
+        internal HttpContentHeaders(SystemHttpContentHeaders contentHeadersStore)
+        {
+            this.contentHeadersStore = contentHeadersStore;
+        }
+        
+        internal HttpContentHeaders()
+        {
+            contentHeadersStore = new System.Net.Http.ByteArrayContent(new byte[]{}).Headers;
+        }
+
+        public HttpHeaderValueCollection<string> Allow =>
+            new HttpHeaderValueCollection<string>(
+                contentHeadersStore.Allow as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
+
+        public ContentDispositionHeaderValue ContentDisposition
+        {
+            get => contentHeadersStore.ContentDisposition;
+            set => contentHeadersStore.ContentDisposition = value;
+        }
+
+        public HttpHeaderValueCollection<string> ContentEncoding => new HttpHeaderValueCollection<string>(
+            contentHeadersStore.ContentEncoding as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
+
+        public HttpHeaderValueCollection<string> ContentLanguage => new HttpHeaderValueCollection<string>(
+            contentHeadersStore.ContentLanguage as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
+
+        public long? ContentLength
+        {
+            get => contentHeadersStore.ContentLength;
+            set => contentHeadersStore.ContentLength = value;
+        }
+
+        public Uri ContentLocation
+        {
+            get => contentHeadersStore.ContentLocation;
+            set => contentHeadersStore.ContentLocation = value;
+        }
+
+        public byte[] ContentMD5
+        {
+            get => contentHeadersStore.ContentMD5;
+            set => contentHeadersStore.ContentMD5 = value;
+        }
+
+        public ContentRangeHeaderValue ContentRange
+        {
+            get => contentHeadersStore.ContentRange;
+            set => contentHeadersStore.ContentRange = value;
+        }
+
+        public MediaTypeHeaderValue ContentType
+        {
+            get => contentHeadersStore.ContentType;
+            set => contentHeadersStore.ContentType = value;
+        }
+
+        public DateTimeOffset? Expires
+        {
+            get => contentHeadersStore.Expires;
+            set => contentHeadersStore.Expires = value;
+        }
+
+        public DateTimeOffset? LastModified
+        {
+            get => contentHeadersStore.LastModified;
+            set => contentHeadersStore.LastModified = value;
+        }
+    }
+}

--- a/src/MockNet/Http/Headers/HttpRequestHeaders.cs
+++ b/src/MockNet/Http/Headers/HttpRequestHeaders.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using SystemHttpRequestHeaders = System.Net.Http.Headers.HttpRequestHeaders;
 using SystemMediaTypeWithQualityHeaderValue = System.Net.Http.Headers.MediaTypeWithQualityHeaderValue;
 using SystemTransferCodingWithQualityHeaderValue = System.Net.Http.Headers.TransferCodingWithQualityHeaderValue;
@@ -19,12 +17,12 @@ namespace Theorem.MockNet.Http
 {
     public sealed class HttpRequestHeaders : HttpHeaders
     {
-        private SystemHttpContentHeaders contentHeadersStore;
+        private readonly HttpContentHeaders contentHeaders;
 
         internal HttpRequestHeaders(SystemHttpRequestHeaders store, SystemHttpContentHeaders contentHeadersStore)
         {
             this.store = store ?? throw new ArgumentNullException(nameof(store));
-            this.contentHeadersStore = contentHeadersStore;
+            contentHeaders = new HttpContentHeaders(contentHeadersStore);
         }
 
         internal SystemHttpRequestHeaders Store => store as SystemHttpRequestHeaders;
@@ -62,17 +60,19 @@ namespace Theorem.MockNet.Http
         public HttpHeaderValueCollection<WarningHeaderValue, SystemWarningHeaderValue> Warning => new HttpHeaderValueCollection<WarningHeaderValue, SystemWarningHeaderValue>(Store.Warning, x => (WarningHeaderValue)x);
 
         #region Content headers
-        public HttpHeaderValueCollection<string> Allow => new HttpHeaderValueCollection<string>(contentHeadersStore.Allow as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
-        public ContentDispositionHeaderValue ContentDisposition { get => contentHeadersStore.ContentDisposition; set => contentHeadersStore.ContentDisposition = value; }
-        public HttpHeaderValueCollection<string> ContentEncoding => new HttpHeaderValueCollection<string>(contentHeadersStore.ContentEncoding as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
-        public HttpHeaderValueCollection<string> ContentLanguage => new HttpHeaderValueCollection<string>(contentHeadersStore.ContentEncoding as System.Net.Http.Headers.HttpHeaderValueCollection<string>);
-        public long? ContentLength { get => contentHeadersStore.ContentLength; set => contentHeadersStore.ContentLength = value; }
-        public Uri ContentLocation { get => contentHeadersStore.ContentLocation; set => contentHeadersStore.ContentLocation = value; }
-        public byte[] ContentMD5 { get => contentHeadersStore.ContentMD5; set => contentHeadersStore.ContentMD5 = value; }
-        public ContentRangeHeaderValue ContentRange { get => contentHeadersStore.ContentRange; set => contentHeadersStore.ContentRange = value; }
-        public MediaTypeHeaderValue ContentType { get => contentHeadersStore.ContentType; set => contentHeadersStore.ContentType = value; }
-        public DateTimeOffset? Expires { get => contentHeadersStore.Expires; set => contentHeadersStore.Expires = value; }
-        public DateTimeOffset? LastModified { get => contentHeadersStore.LastModified; set => contentHeadersStore.LastModified = value; }
+
+        public HttpHeaderValueCollection<string> Allow => contentHeaders.Allow;
+        public ContentDispositionHeaderValue ContentDisposition => contentHeaders.ContentDisposition;
+        public HttpHeaderValueCollection<string> ContentEncoding => contentHeaders.ContentEncoding;
+        public HttpHeaderValueCollection<string> ContentLanguage => contentHeaders.ContentLanguage;
+        public long? ContentLength => contentHeaders.ContentLength;
+        public Uri ContentLocation => contentHeaders.ContentLocation;
+        public byte[] ContentMD5 => contentHeaders.ContentMD5;
+        public ContentRangeHeaderValue ContentRange => contentHeaders.ContentRange;
+        public MediaTypeHeaderValue ContentType => contentHeaders.ContentType;
+        public DateTimeOffset? Expires => contentHeaders.Expires;
+        public DateTimeOffset? LastModified => contentHeaders.LastModified;
+
         #endregion
     }
 }

--- a/src/MockNet/Http/IReturns.cs
+++ b/src/MockNet/Http/IReturns.cs
@@ -8,9 +8,9 @@ namespace Theorem.MockNet.Http
         IReturns ReturnsAsync(int code);
 
         /// <summary>
-        /// Specifies the <see cref="IHttpContent" /> to return.
+        /// Specifies the <see cref="HttpContent" /> to return.
         /// </summary>
-        IReturns ReturnsAsync<THttpContent>(THttpContent content) where THttpContent : IHttpContent;
+        IReturns ReturnsAsync<THttpContent>(THttpContent content) where THttpContent : HttpContent;
 
         /// <summary>
         /// Specifies any <see cref="HttpResponseHeaders" /> to return.
@@ -18,9 +18,9 @@ namespace Theorem.MockNet.Http
         IReturns ReturnsAsync(HttpResponseHeaders headers);
 
         /// <summary>
-        /// Specifies the HTTP status code and the <see cref="IHttpContent" /> to return.
+        /// Specifies the HTTP status code and the <see cref="HttpContent" /> to return.
         /// </summary>
-        IReturns ReturnsAsync<THttpContent>(int code, THttpContent content) where THttpContent : IHttpContent;
+        IReturns ReturnsAsync<THttpContent>(int code, THttpContent content) where THttpContent : HttpContent;
 
         /// <summary>
         /// Specifies the HTTP status code and any <see cref="HttpResponseHeaders" /> to return.
@@ -28,14 +28,14 @@ namespace Theorem.MockNet.Http
         IReturns ReturnsAsync(int code, HttpResponseHeaders headers);
 
         /// <summary>
-        /// Specifies any <see cref="HttpResponseHeader" /> and the <see cref="IHttpContent" /> to return.
+        /// Specifies any <see cref="HttpResponseHeader" /> and the <see cref="HttpContent" /> to return.
         /// </summary>
-        IReturns ReturnsAsync<THttpContent>(HttpResponseHeaders headers, THttpContent content) where THttpContent : IHttpContent;
+        IReturns ReturnsAsync<THttpContent>(HttpResponseHeaders headers, THttpContent content) where THttpContent : HttpContent;
 
         /// <summary>
-        /// Specifies the HTTP status code, any <see cref="HttpResponseHeaders" /> and the <see cref="IHttpContent" /> to return.
+        /// Specifies the HTTP status code, any <see cref="HttpResponseHeaders" /> and the <see cref="HttpContent" /> to return.
         /// </summary>
-        IReturns ReturnsAsync<THttpContent>(int code, HttpResponseHeaders headers, THttpContent content) where THttpContent : IHttpContent;
+        IReturns ReturnsAsync<THttpContent>(int code, HttpResponseHeaders headers, THttpContent content) where THttpContent : HttpContent;
 
         /// <summary>
         /// Specifies the content to return.

--- a/src/MockNet/Http/Internal/HttpResponseMessageBuilder.cs
+++ b/src/MockNet/Http/Internal/HttpResponseMessageBuilder.cs
@@ -8,7 +8,7 @@ namespace Theorem.MockNet.Http
     {
         private SystemHttpStatusCode code = SystemHttpStatusCode.OK;
         private HttpResponseHeaders headers;
-        private IHttpContent content;
+        private HttpContent content;
 
         public HttpResponseMessageBuilder WithStatusCode(int code)
         {
@@ -24,7 +24,7 @@ namespace Theorem.MockNet.Http
             return this;
         }
 
-        public HttpResponseMessageBuilder WithContent(IHttpContent content)
+        public HttpResponseMessageBuilder WithContent(HttpContent content)
         {
             this.content = content;
 
@@ -35,7 +35,7 @@ namespace Theorem.MockNet.Http
         {
             var message = new SystemHttpResponseMessage(code);
 
-            if (content is IHttpContent)
+            if (content is HttpContent)
             {
                 message.Content = content.ToHttpContent();
             }

--- a/src/MockNet/Http/Internal/Setup.cs
+++ b/src/MockNet/Http/Internal/Setup.cs
@@ -23,30 +23,30 @@ namespace Theorem.MockNet.Http
 
         public IReturns ReturnsAsync(int code)
         {
-            return ReturnsAsync(code, null, (IHttpContent)null);
+            return ReturnsAsync(code, null, (HttpContent)null);
         }
 
-        public IReturns ReturnsAsync<THttpContent>(THttpContent content) where THttpContent : IHttpContent
+        public IReturns ReturnsAsync<THttpContent>(THttpContent content) where THttpContent : HttpContent
         {
             return ReturnsAsync(defaultHttpStatusCode, null, content);
         }
 
         public IReturns ReturnsAsync(HttpResponseHeaders headers)
         {
-            return ReturnsAsync(defaultHttpStatusCode, headers, (IHttpContent)null);
+            return ReturnsAsync(defaultHttpStatusCode, headers, (HttpContent)null);
         }
 
-        public IReturns ReturnsAsync<THttpContent>(int code, THttpContent content) where THttpContent : IHttpContent
+        public IReturns ReturnsAsync<THttpContent>(int code, THttpContent content) where THttpContent : HttpContent
         {
             return ReturnsAsync(code, null, content);
         }
 
         public IReturns ReturnsAsync(int code, HttpResponseHeaders headers)
         {
-            return ReturnsAsync(code, headers, (IHttpContent)null);
+            return ReturnsAsync(code, headers, (HttpContent)null);
         }
 
-        public IReturns ReturnsAsync<THttpContent>(HttpResponseHeaders headers, THttpContent content) where THttpContent : IHttpContent
+        public IReturns ReturnsAsync<THttpContent>(HttpResponseHeaders headers, THttpContent content) where THttpContent : HttpContent
         {
             return ReturnsAsync(defaultHttpStatusCode, headers, content);
         }
@@ -55,7 +55,7 @@ namespace Theorem.MockNet.Http
         {
             return ReturnsAsync(defaultHttpStatusCode, null,
                 content is null
-                    ? (IHttpContent)null
+                    ? (HttpContent)null
                     : new ObjectContent(content.GetType(), content));
         }
 
@@ -63,7 +63,7 @@ namespace Theorem.MockNet.Http
         {
             return ReturnsAsync(code, null,
                 content is null
-                    ? (IHttpContent)null
+                    ? (HttpContent)null
                     : new ObjectContent(content.GetType(), content));
         }
 
@@ -71,7 +71,7 @@ namespace Theorem.MockNet.Http
         {
             return ReturnsAsync(code, headers,
                 content is null
-                    ? (IHttpContent)null
+                    ? (HttpContent)null
                     : new ObjectContent(content.GetType(), content));
         }
 
@@ -79,11 +79,11 @@ namespace Theorem.MockNet.Http
         {
             return ReturnsAsync(defaultHttpStatusCode, headers,
                 content is null
-                    ? (IHttpContent)null
+                    ? (HttpContent)null
                     : new ObjectContent(content.GetType(), content));
         }
 
-        public IReturns ReturnsAsync<THttpContent>(int code, HttpResponseHeaders headers, THttpContent content) where THttpContent : IHttpContent
+        public IReturns ReturnsAsync<THttpContent>(int code, HttpResponseHeaders headers, THttpContent content) where THttpContent : HttpContent
         {
             var message = new HttpResponseMessageBuilder()
                 .WithStatusCode(code)


### PR DESCRIPTION
This PR adds a HttpContentHeaders class to the library. This class contains all headers, related to the content. 
Also, HttpContensHeaders are added to all content types by introducing base class HttpContent instead of IHttpContent interface. 